### PR TITLE
Fix /auth replace

### DIFF
--- a/src/keycloakAuthorizer.js
+++ b/src/keycloakAuthorizer.js
@@ -1,7 +1,7 @@
 const jsonwebtoken = require('jsonwebtoken');
 
 const KeyCloakCerts = require('get-keycloak-public-key');
-const { getKeycloakUrl } = require('./utils/restCalls');
+const { getKeycloakUrl, getUrl } = require('./utils/restCalls');
 const { enforce } = require('./umaConfiguration');
 const { commonOptions } = require('./utils/optionsUtils');
 
@@ -9,8 +9,9 @@ async function getKeyFromKeycloak(options, kid) {
   let publicKey = await options.cache.get('publicKey', kid);
   if (!publicKey) {
     const kJson = options.keycloakJson(options);
-    const keycloakUrl = getKeycloakUrl(kJson).replace('/auth', '');
-    publicKey = await KeyCloakCerts(keycloakUrl,
+    const keycloakUrl = new URL(getKeycloakUrl(kJson));
+    keycloakUrl.pathname = keycloakUrl.pathname.replace('/auth', '');
+    publicKey = await KeyCloakCerts(getUrl(keycloakUrl.toString()),
       kJson.realm).fetch(kid);
     await options.cache.put('publicKey', kid, publicKey);
   }


### PR DESCRIPTION
We encountered an issue when our Keycloak URL was `https://auth.domain.com`, because the `.replace('/auth', '')` replaced the first occurrence of `/auth` in our full URL.

This PR uses the JS `URL` class to split the string into the different segments of the URL, replaces `/auth` in the path after the domain in the URL. Then I call the `getUrl` method to remove the remaining trailing slash.

This will ensure that only the first instance of `/auth` in the path following the domain name in the URL is replaced.