### PR TITLE
Matching case-sensitive authentication scheme

### DIFF
--- a/src/adapters/ApigatewayAdapter.test.ts
+++ b/src/adapters/ApigatewayAdapter.test.ts
@@ -34,6 +34,26 @@ describe('ApigatewayAdapter tests', () => {
     });
   });
 
+  test('validate authentication scheme is case-insensitive test', async () => {
+    // @ts-ignore
+    const ret = await new DefaultApigatewayAdapter({securityAdapter: new DummySecurityAdapter()}).validate({
+      headers: {
+        Authorization: "bearer JWT",
+      },
+    });
+    expect(ret).toEqual({
+      token: {
+        header: {
+          alg: "alg",
+          kid: "1",
+        },
+        payload: {},
+        tokenString: "JWT",
+      },
+      tokenString: "JWT",
+    });
+  });
+
   test('validate authorizationToken test', async () => {
     // @ts-ignore
     const ret = await new DefaultApigatewayAdapter({securityAdapter: new DummySecurityAdapter()}).validate({

--- a/src/adapters/ApigatewayAdapter.ts
+++ b/src/adapters/ApigatewayAdapter.ts
@@ -38,7 +38,7 @@ export class DefaultApigatewayAdapter implements ApigatewayAdapter {
     if (!tokenString) {
       throw new Error('Expected \'event.authorizationToken\' parameter to be set');
     }
-    const match = tokenString.match(/^Bearer (.*)$/);
+    const match = tokenString.match(/^Bearer (.*)$/i);
     if (!match || match.length < 2) {
       throw new Error(`Invalid Authorization token - '${tokenString}' does not match 'Bearer .*'`);
     }

--- a/src/adapters/MiddlewareAdapter.test.ts
+++ b/src/adapters/MiddlewareAdapter.test.ts
@@ -29,6 +29,21 @@ describe('MiddlewareAdapter tests', () => {
     }
   });
 
+  test('MiddlewareAdapter case-insensitive authorization scheme test', async () => {
+    let next = false;
+    // @ts-ignore
+    await new DefaultMiddlewareAdapter({securityAdapter: new DummySecurityAdapter()}).middleware()({
+      headers: {
+        authorization: "bearer JWT",
+      },
+    }, {}, () => {
+      next = true;
+    });
+    if (!next) {
+      throw new Error('test');
+    }
+  });
+
   test('MiddlewareAdapter test 2', async () => {
     let next = false;
     // @ts-ignore

--- a/src/adapters/MiddlewareAdapter.ts
+++ b/src/adapters/MiddlewareAdapter.ts
@@ -28,7 +28,7 @@ export class DefaultMiddlewareAdapter implements MiddlewareAdapter {
     if (!tokenString) {
       throw new Error('Expected \'headers.authorization\' parameter to be set');
     }
-    const match = tokenString.match(/^Bearer (.*)$/);
+    const match = tokenString.match(/^Bearer (.*)$/i);
     if (!match || match.length < 2) {
       throw new Error(`Invalid Authorization token - '${tokenString}' does not match 'Bearer .*'`);
     }


### PR DESCRIPTION
The authentication scheme [should be case-insensitive](https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/Authorization#directives).

This PR removes case-sensitivity from the regexes that are used for header validation.